### PR TITLE
Remove bashisms in bin/clone

### DIFF
--- a/bin/clone
+++ b/bin/clone
@@ -1,8 +1,7 @@
 #!/bin/sh
-pushd cloned
+cd cloned
 git clone git@github.com:zordius/lightncandy.git
 git clone git@github.com:bobthecow/mustache.php.git
 git clone git@github.com:dingram/mustache-php.git
 git clone git@github.com:XaminProject/handlebars.php.git
-popd
-
+cd -


### PR DESCRIPTION
pushd/popd are not supported in all /bin/sh implementations, use the
more standard `cd -` to return to initial position. The `cd -` may
actually be completely unnecessary though, as long as the script
is executed rather than sourced the final directory change has no effect.
