### PR TITLE
Tests for empty array and object in section and each

### DIFF
--- a/fixture/006-simple-section-010.json
+++ b/fixture/006-simple-section-010.json
@@ -1,0 +1,6 @@
+{
+    "name": "John",
+    "value": 10000,
+    "people": []
+}
+

--- a/fixture/006-simple-section-010.lightncandy.txt
+++ b/fixture/006-simple-section-010.lightncandy.txt
@@ -1,0 +1,5 @@
+Hello John, you have just won $10000!
+<ul>
+
+</ul>
+

--- a/fixture/006-simple-section-010.txt
+++ b/fixture/006-simple-section-010.txt
@@ -1,0 +1,5 @@
+Hello John, you have just won $10000!
+<ul>
+
+</ul>
+

--- a/fixture/006-simple-section-011.json
+++ b/fixture/006-simple-section-011.json
@@ -1,0 +1,6 @@
+{
+    "name": "John",
+    "value": 10000,
+    "people": {}
+}
+

--- a/fixture/006-simple-section-011.lightncandy.txt
+++ b/fixture/006-simple-section-011.lightncandy.txt
@@ -1,0 +1,5 @@
+Hello John, you have just won $10000!
+<ul>
+
+</ul>
+

--- a/fixture/006-simple-section-011.txt
+++ b/fixture/006-simple-section-011.txt
@@ -1,0 +1,7 @@
+Hello John, you have just won $10000!
+<ul>
+
+ <li> is a </li>
+
+</ul>
+

--- a/fixture/013-hb-each-010.json
+++ b/fixture/013-hb-each-010.json
@@ -1,0 +1,6 @@
+{
+    "name": "John",
+    "value": 10000,
+    "people": []
+}
+

--- a/fixture/013-hb-each-010.lightncandy.txt
+++ b/fixture/013-hb-each-010.lightncandy.txt
@@ -1,0 +1,5 @@
+Hello John, you have just won $10000!
+<ul>
+
+</ul>
+

--- a/fixture/013-hb-each-010.txt
+++ b/fixture/013-hb-each-010.txt
@@ -1,0 +1,5 @@
+Hello John, you have just won $10000!
+<ul>
+
+</ul>
+

--- a/fixture/013-hb-each-011.json
+++ b/fixture/013-hb-each-011.json
@@ -1,0 +1,6 @@
+{
+    "name": "John",
+    "value": 10000,
+    "people": {}
+}
+

--- a/fixture/013-hb-each-011.lightncandy.txt
+++ b/fixture/013-hb-each-011.lightncandy.txt
@@ -1,0 +1,5 @@
+Hello John, you have just won $10000!
+<ul>
+
+</ul>
+

--- a/fixture/013-hb-each-011.txt
+++ b/fixture/013-hb-each-011.txt
@@ -1,0 +1,5 @@
+Hello John, you have just won $10000!
+<ul>
+
+</ul>
+


### PR DESCRIPTION
One of these tests, 006-simple-section-011.json, does not pass with
the current lightncandy.  This is because {"foo": {}, "bar": []} has
the same output with json_decode($json, true) for both foo and bar.

To resolve the issue lightncandy would at some point in the future
need to handle popo's in the input data.
